### PR TITLE
Update IRC metadata to libera.chat

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,7 @@ WriteMakefile(
         url  => 'https://github.com/mojolicious/sql-abstract-pg.git',
         web  => 'https://github.com/mojolicious/sql-abstract-pg',
       },
-      x_IRC => {url => 'irc://chat.freenode.net/#mojo', web => 'https://webchat.freenode.net/#mojo'}
+      x_IRC => {url => 'irc://irc.libera.chat/#mojo', web => 'https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#mojo'}
     },
   },
   PREREQ_PM => {'SQL::Abstract' => '2.0'},


### PR DESCRIPTION
### Summary
Update #mojo metadata to libera.chat

### Motivation
IRC channel is moving

### References
https://github.com/mojolicious/mojo/pull/1788
