### PR TITLE
Update webchat metadata to web.libera.chat

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,7 @@ WriteMakefile(
         url  => 'https://github.com/mojolicious/sql-abstract-pg.git',
         web  => 'https://github.com/mojolicious/sql-abstract-pg',
       },
-      x_IRC => {url => 'irc://irc.libera.chat/#mojo', web => 'https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#mojo'}
+      x_IRC => {url => 'irc://irc.libera.chat/#mojo', web => 'https://web.libera.chat/#mojo'}
     },
   },
   PREREQ_PM => {'SQL::Abstract' => '2.0'},


### PR DESCRIPTION
### Summary
Use https://web.libera.chat/#mojo for webchat metadata.

### Motivation
Simpler links using the official libera.chat webchat

### References
https://github.com/mojolicious/mojo/pull/1789
