### PR TITLE
allow aliases in arrayref table join syntax

### DIFF
--- a/lib/SQL/Abstract/Pg.pm
+++ b/lib/SQL/Abstract/Pg.pm
@@ -172,7 +172,7 @@ sub _table {
     my ($type, $name, $fk, $pk, @morekeys) = @$join % 2 == 0 ? @$join : ('', @$join);
     $table
       .= $self->_sqlcase($type =~ /^-(.+)$/ ? " $1 join " : ' join ')
-      . $self->_quote($name)
+      . $self->_table($name)
       . $self->_sqlcase(' on ') . '(';
     do {
       $table
@@ -284,6 +284,9 @@ with tables to generate C<JOIN> clauses for.
 
   # "SELECT * FROM a LEFT JOIN b ON (b.a_id = a.id AND b.a_id2 = a.id2)"
   $abstract->select(['a', [-left => 'b', a_id => 'id', a_id2 => 'id2']]);
+
+  # "SELECT * FROM foo f JOIN bar b ON (b.foo_id = f.id)"
+  $abstract->select([\'foo f', [\'bar b', 'b.foo_id' => 'f.id']]);
 
 =head2 ORDER BY
 

--- a/t/sql.t
+++ b/t/sql.t
@@ -146,6 +146,12 @@ subtest 'JOIN' => sub {
       . ' AND "bar"."foo_id2" = "foo"."id2"'
       . ' AND "bar"."foo_id3" = "foo"."id3"' . ')'
     ], 'right query';
+  @sql = $abstract->select([\'"foo" "f"', [\'"bar" "b"', 'b.foo_id' => 'f.id']]);
+  is_query \@sql, ['SELECT * FROM "foo" "f" JOIN "bar" "b" ON ("b"."foo_id" = "f"."id")'], 'right query';
+  @sql = $abstract->select([\'"foo" "f"', [-left, \'"bar" "b"', 'b.foo_id' => 'f.id']]);
+  is_query \@sql, ['SELECT * FROM "foo" "f" LEFT JOIN "bar" "b" ON ("b"."foo_id" = "f"."id")'], 'right query';
+  @sql = $abstract->select(['foo', [\'"bar" "b"', 'b.foo_id' => 'id']]);
+  is_query \@sql, ['SELECT * FROM "foo" JOIN "bar" "b" ON ("b"."foo_id" = "foo"."id")'], 'right query';
 };
 
 subtest 'JOIN (unsupported value)' => sub {


### PR DESCRIPTION
### Summary
In the arrayref syntax of table joins, I allow table names to appear with aliases, like so:

```perl
$db->select([
    \'people AS parents',
    [\'people AS children', 'children.parent_id' => 'parents.id'],
]);
```

### Motivation
This change is necessary, in order to allow a table to join itself in a query. Without this change, one would have to write a long SCALARREF instead of the arrayref syntax, like so:

```perl
$db->select(\'people AS parents JOIN people AS children ON (children.parent_id = parents.id)');
```

### References
#3
